### PR TITLE
Added format parameter

### DIFF
--- a/Player.hx
+++ b/Player.hx
@@ -28,6 +28,7 @@ class Player extends flash.events.EventDispatcher, implements IPlayer {
     var padding : Array<Float>;
     var in_off : Array<Float>;
     var fname : String;
+    var format : String;
     var first : Bool;
     var timer : flash.utils.Timer;
     var trigger : Null<Float>;
@@ -38,10 +39,11 @@ class Player extends flash.events.EventDispatcher, implements IPlayer {
     public var pan(getPan, setPan): Float;
     public var soundTransform(getST, setST): SoundTransform;
 
-    public function new(?path : String) {
+    public function new(?path : String, ?formattype : String) {
         super();
         schtr = new SoundTransform();
         fname = path;
+        format = formattype;
         asink = null;
         File = null;
     }
@@ -54,31 +56,31 @@ class Player extends flash.events.EventDispatcher, implements IPlayer {
         pitch = new Array<Float>();
         trace("Player for "+fname);
         var slnrx = ~/[.](sln(\d{1,3}))$/i;
-        if ((~/[.]au$/i).match(fname)) {
+        if ((~/[.]au$/i).match(fname) || format == "au") {
             Sound = new fmt.FileAu();
         } else
-        if ((~/[.]wav(49)?$/i).match(fname)) {
+        if ((~/[.]wav(49)?$/i).match(fname) || (~/^wave?$/).match(format)) {
             Sound = new fmt.FileWav();
         } else
-        if ((~/[.](sln|raw)$/i).match(fname)) {
+        if ((~/[.](sln|raw)$/i).match(fname) || (~/^(sln|raw)$/).match(format)) {
             Sound = new fmt.FileSln();
         } else
-        if (slnrx.match(fname)) {
+        if (slnrx.match(fname) || (~/^(sln(\d{1,3}))$/).match(format)) {
             Sound = new fmt.FileSln(Std.parseInt(slnrx.matched(2)) * 1000);
         } else
-        if ((~/[.](alaw|al)$/i).match(fname)) {
+        if ((~/[.](alaw|al)$/i).match(fname) || (~/^(alaw|al)$/).match(format)) {
             Sound = new fmt.FileAlaw();
         } else
-        if ((~/[.](ulaw|ul|pcm|mu)$/i).match(fname)) {
+        if ((~/[.](ulaw|ul|pcm|mu)$/i).match(fname) || (~/^(ulaw|ul|pcm|mu)$/).match(format)) {
             Sound = new fmt.FileUlaw();
         } else
-        if ((~/[.]la$/i).match(fname)) {
+        if ((~/[.]la$/i).match(fname) || format == "la") {
             Sound = new fmt.FileAlawInv();
         } else
-        if ((~/[.]lu$/i).match(fname)) {
+        if ((~/[.]lu$/i).match(fname) || format == "lu") {
             Sound = new fmt.FileUlawInv();
         } else
-        if ((~/[.]gsm$/i).match(fname)) {
+        if ((~/[.]gsm$/i).match(fname) || format == "gsm") {
             Sound = new fmt.FileGsm();
         } else {
             trace("Unsupported file type");

--- a/WavPlayer.hx
+++ b/WavPlayer.hx
@@ -367,7 +367,7 @@ class WavPlayer {
 
         iface.drawStopped();
 		
-		initPlayerForUrl(fvs.sound);		
+        initPlayerForUrl(fvs.sound, fvs.format);
         player.volume = volume;
         player.pan = pan;
 		
@@ -409,10 +409,10 @@ class WavPlayer {
             flash.external.ExternalInterface.call("onWavPlayerReady", flash.external.ExternalInterface.objectID);
     }
 	
-	static function initPlayerForUrl(?path: String) {
+    static function initPlayerForUrl(?path: String, ?format: String) {
 		if(path == null && player != null) return;
 		
-		if(path != null && (~/[.]mp3$/i).match(path)) {
+		if(path != null && ((~/[.]mp3$/i).match(path) || format == "mp3")) {
 			if(mp3player == null) {
 				mp3player = new Mp3Player(path);
 				AddPlayerEventListeners(mp3player);
@@ -421,7 +421,7 @@ class WavPlayer {
         }
 		else {
 			if(wavplayer == null) {
-				wavplayer = new Player(path);
+				wavplayer = new Player(path, format);
 				AddPlayerEventListeners(wavplayer);
 			}
 			player = wavplayer;

--- a/WavPlayer.hx
+++ b/WavPlayer.hx
@@ -409,7 +409,7 @@ class WavPlayer {
             flash.external.ExternalInterface.call("onWavPlayerReady", flash.external.ExternalInterface.objectID);
     }
 	
-    static function initPlayerForUrl(?path: String, ?format: String) {
+	static function initPlayerForUrl(?path: String, ?format: String) {
 		if(path == null && player != null) return;
 		
 		if(path != null && ((~/[.]mp3$/i).match(path) || format == "mp3")) {


### PR DESCRIPTION
François,
I've added support for a _format_ parameter to allow you to specify a format when the _sound_ path is non-specific.

I was attempting to use WavPlayer to play WAV files in a helpdesk application (Spiceworks) that uses an obfuscated URL to link to attachments.  It did, however, have the real filename in the innerHTML of the anchor tag.  With this patch, I'm able to detect the file type in JS and then link to WavPlayer like this:

```
wavplayer.swf?gui=full&h=30&w=300&sound=/attachment/854&format=wav&
```

I did **not** update the WavPlayer JS interfaces such as DoPlay() to accommodate a format parameter.
